### PR TITLE
Test/UI Add integration and unit tests for task editing components

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -15,7 +15,10 @@ export default defineConfig([
     ],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: {
+	      ...globals.browser,
+        ...globals.vitest
+      },
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: { jsx: true },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
@@ -21,8 +23,56 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
-        "vite": "^7.3.1"
+        "jsdom": "^29.0.2",
+        "vite": "^7.3.1",
+        "vitest": "^4.1.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.8.tgz",
+      "integrity": "sha512-OISPR9c2uPo23rUdvfEQiLPjoMLOpEeLNnP5iGkxr6tDDxJd3NjD+6fxY0mdaMbIPUjFGL4HFOJqLvow5q4aqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.8.tgz",
+      "integrity": "sha512-erMO6FgtM02dC24NGm0xufMzWz5OF0wXKR7BpvGD973bq/GbmR8/DbxNZbj0YevQ5hlToJaWSVK/G9/NDgGEVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -258,6 +308,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -304,6 +364,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
+      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -905,6 +1118,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1364,6 +1595,97 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1408,6 +1730,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1464,6 +1804,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1504,6 +1957,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1527,6 +1991,26 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1547,10 +2031,20 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1623,6 +2117,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1689,12 +2193,47 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1714,6 +2253,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1721,12 +2267,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
       "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -1967,6 +2551,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1975,6 +2569,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2145,6 +2749,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2182,6 +2799,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2204,6 +2831,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2230,6 +2864,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -2336,6 +3021,44 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
@@ -2387,6 +3110,17 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -2452,6 +3186,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2472,6 +3219,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2480,9 +3234,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2531,6 +3285,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2562,10 +3346,42 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
       "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2627,6 +3443,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -2666,6 +3495,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2674,6 +3510,33 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -2702,6 +3565,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2719,6 +3606,62 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -2730,6 +3673,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -2774,9 +3727,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2848,6 +3801,144 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2864,6 +3955,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -2873,6 +3981,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@eslint/js": "^9.39.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
@@ -1676,6 +1677,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@eslint/js": "^9.39.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "react": "^19.2.0",
@@ -16,6 +17,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
@@ -23,6 +26,8 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
-    "vite": "^7.3.1"
+    "jsdom": "^29.0.2",
+    "vite": "^7.3.1",
+    "vitest": "^4.1.4"
   }
 }

--- a/frontend/src/components/Quadrant/Quadrant.test.jsx
+++ b/frontend/src/components/Quadrant/Quadrant.test.jsx
@@ -1,4 +1,3 @@
-// integration test
 import { render, screen } from '../../../testSetup';
 import { TASKS_LS_KEY } from '../../hooks/useTasks';
 import Quadrant from './index';

--- a/frontend/src/components/Quadrant/Quadrant.test.jsx
+++ b/frontend/src/components/Quadrant/Quadrant.test.jsx
@@ -1,0 +1,91 @@
+// integration test
+import { render, screen } from '../../../testSetup';
+import { TASKS_LS_KEY } from '../../hooks/useTasks';
+import Quadrant from './index';
+
+const config = {
+    label: 'Do First',
+    action: 'Tackle immediately',
+    cssVarBg: '--color-q1-bg',
+    cssVarBorder: '--color-q1-border',
+    cssVarText: '--color-q1-text',
+};
+
+const TASKS = [
+  {
+    id: 'task-1',
+    text: 'Urgent task',
+    urgent: true,
+    important: true,
+    status: 'active',
+    createdAt: new Date().toISOString(),
+    completedAt: null,
+    deletedAt: null,
+  },
+  {
+    id: 'task-2',
+    text: 'Another task',
+    urgent: true,
+    important: true,
+    status: 'active',
+    createdAt: new Date().toISOString(),
+    completedAt: null,
+    deletedAt: null,
+  },
+];
+
+const mockOnEdit = vi.fn();
+const mockOnCancelEdit = vi.fn();
+
+function renderQuadrant(tasks = TASKS, editingTaskId = null) {
+  localStorage.setItem(TASKS_LS_KEY, JSON.stringify(tasks));
+  return render(
+    <Quadrant
+      config={config}
+      tasks={tasks}
+      editingTaskId={editingTaskId}
+      onEdit={mockOnEdit}
+      onCancelEdit={mockOnCancelEdit}
+    />
+  );
+}
+
+describe('Quadrant', () => {
+  it('should render the quadrant label and action', () => {
+    renderQuadrant();
+    expect(screen.getByText('Do First')).toBeInTheDocument();
+    expect(screen.getByText('Tackle immediately')).toBeInTheDocument();
+  });
+
+  it('should render the correct task count', () => {
+    renderQuadrant();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('should render empty state when there are no tasks', () => {
+    renderQuadrant([]);
+    expect(screen.getByText(/no tasks here/i)).toBeInTheDocument();
+  });
+
+  it('should not render empty state when tasks exist', () => {
+    renderQuadrant();
+    expect(screen.queryByText(/no tasks here/i)).not.toBeInTheDocument();
+  });
+
+  it('should render all tasks', () => {
+    renderQuadrant();
+    expect(screen.getByText(/Urgent task/)).toBeInTheDocument();
+    expect(screen.getByText(/Another task/)).toBeInTheDocument();
+  });
+
+  it('should put only the matching task into edit mode', () => {
+    renderQuadrant(TASKS, 'task-1');
+    expect(screen.getByRole('textbox')).toHaveValue('Urgent task');
+    expect(screen.getByText(/Another task/)).toBeInTheDocument();
+  });
+
+  it('should render no inputs when editingTaskId is null', () => {
+    renderQuadrant(TASKS, null);
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Quadrant/TaskEditForm.css
+++ b/frontend/src/components/Quadrant/TaskEditForm.css
@@ -18,3 +18,10 @@
   font-size: 11px;
   color: var(--color-danger);
 }
+
+.info {
+  margin: 0;
+  padding-left: 0.1rem;
+  font-size: 11px;
+  color: var( --color-text-hint);
+}

--- a/frontend/src/components/Quadrant/TaskEditForm.jsx
+++ b/frontend/src/components/Quadrant/TaskEditForm.jsx
@@ -44,9 +44,11 @@ const TaskEditForm = ({ initialText, onSave, onCancel }) => {
         onChange={handleChange}
         onBlur={handleBlur}
         onKeyDown={handleKeyDown}
-        title="ESC to cancel edit"
       />
-      {error && <span className="error">{error}</span>}
+      {error 
+        ? <span className="error">{error}</span>
+        : <span className="info">Press the <kbd>Esc</kbd> or <kbd>Tab</kbd> key to cancel editing</span>
+      }
     </>
   );
 };

--- a/frontend/src/components/Quadrant/TaskEditForm.jsx
+++ b/frontend/src/components/Quadrant/TaskEditForm.jsx
@@ -24,13 +24,23 @@ const TaskEditForm = ({ initialText, onSave, onCancel }) => {
     if (!err) {
       onSave(text.trim());
     } else {
-      setError(err);
+      onCancel();
     }
   };
 
   const handleKeyDown = (e) => {
-    if (e.key === "Enter") handleBlur();
-    if (e.key === "Escape") onCancel();
+    if (e.key === 'Escape') {
+      onCancel();
+      return;
+    }
+    if (e.key === 'Enter') {
+      const err = validateTaskText(text);
+      if (err) {
+        setError(err);
+        return;
+      }
+      onSave(text.trim());
+    }
   };
 
   return (
@@ -47,7 +57,7 @@ const TaskEditForm = ({ initialText, onSave, onCancel }) => {
       />
       {error 
         ? <span className="error">{error}</span>
-        : <span className="info">Press the <kbd>Esc</kbd> or <kbd>Tab</kbd> key to cancel editing</span>
+        : <span className="info">Press <kbd>Enter</kbd> key to save, <kbd>Esc</kbd> key to cancel editing</span>
       }
     </>
   );

--- a/frontend/src/components/Quadrant/TaskEditForm.test.jsx
+++ b/frontend/src/components/Quadrant/TaskEditForm.test.jsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import TaskEditForm from './TaskEditForm';
+
+const mockOnSave = vi.fn();
+const mockOnCancel = vi.fn();
+
+function renderEditForm(initialText = 'Valid initial text') {
+  return render(
+    <TaskEditForm
+      initialText={initialText}
+      onSave={mockOnSave}
+      onCancel={mockOnCancel}
+    />
+  );
+}
+
+describe('TaskEditForm', () => {
+  it('should render with initialText pre-filled in the input', () => {
+    renderEditForm('My task');
+    expect(screen.getByRole('textbox')).toHaveValue('My task');
+  });
+
+  it('should focus the input on mount', () => {
+    renderEditForm();
+    expect(screen.getByRole('textbox')).toHaveFocus();
+  });
+
+  it('should show info hint when there is no validation error', () => {
+    renderEditForm('Valid task text');
+    expect(screen.getByText(/press/i)).toBeInTheDocument();
+  });
+
+  it('should show an error and hide the hint when text becomes invalid', async () => {
+    
+    const user = userEvent.setup();
+    renderEditForm();
+
+    await user.clear(screen.getByRole('textbox'))
+    await user.keyboard('{Enter}')
+
+    expect(screen.queryByText(/press/i)).not.toBeInTheDocument();
+
+    const errorEl = document.querySelector('.error');
+    expect(errorEl).toBeInTheDocument();
+  });
+
+  it('should call onSave with trimmed text on Enter when valid', async () => {
+    const user = userEvent.setup();
+    renderEditForm();
+
+    await user.clear(screen.getByRole('textbox'))
+    await user.type(screen.getByRole('textbox'), '  Updated task   {Enter}')
+    
+    expect(mockOnSave).toHaveBeenCalledWith('Updated task');
+  });
+
+  it('should not call onSave on Enter when text is invalid', async () => {
+    const user = userEvent.setup();
+    renderEditForm();
+
+    await user.clear(screen.getByRole('textbox'))
+    await user.type(screen.getByRole('textbox'), '     {Enter}')
+
+    const errorEl = document.querySelector('.error');
+    expect(errorEl).toBeInTheDocument();
+    expect(mockOnSave).not.toHaveBeenCalled();
+  });
+
+  it('should call onCancel on Escape key', async () => {
+    const user = userEvent.setup();
+    renderEditForm();
+
+    await user.keyboard('{Escape}')
+
+    expect(mockOnCancel).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/Quadrant/TaskItem.jsx
+++ b/frontend/src/components/Quadrant/TaskItem.jsx
@@ -65,7 +65,7 @@ export default function TaskItem({
       <div className="task-item-body">
         <span 
         className={`task-item-text ${isBusy? "struck" : ""}`} 
-        onClick={() => !isBusy && onEdit()}>
+        onClick={() => !isBusy && onEdit(task.id)}>
           <span className="task-item-date">
             {formatDate(task.createdAt)}
           </span>

--- a/frontend/src/components/Quadrant/TaskItem.jsx
+++ b/frontend/src/components/Quadrant/TaskItem.jsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 
-import { useTaskContext } from "../../context/UseTaskContext";
+import { useTaskContext } from "../../context/useTaskContext";
 import { formatDate } from "../../utils/helpers";
 import TaskEditForm from "./TaskEditForm";
 import "./TaskItem.css";
@@ -17,7 +17,6 @@ export default function TaskItem({
 
   // States
   const [pendingAction, setPendingAction] = useState(null); // 'completing' | 'deleting' | null
-  // const [isEditing, setIsEditing] = useState(false);
   const timerRef = useRef(null);
 
   // Boolean helper to disable buttons

--- a/frontend/src/components/Quadrant/TaskItem.test.jsx
+++ b/frontend/src/components/Quadrant/TaskItem.test.jsx
@@ -1,0 +1,168 @@
+import { render, screen, act, fireEvent } from '../../../testSetup';
+import userEvent from '@testing-library/user-event';
+import { TASKS_LS_KEY } from '../../hooks/useTasks';
+import TaskItem from './TaskItem';
+
+const BASE_TASK = {
+  id: 'task-abc',
+  text: 'Test task item',
+  urgent: true,
+  important: false,
+  status: 'pending',
+  createdAt: new Date().toISOString(),
+  completedAt: null,
+  deletedAt: null,
+};
+
+const mockOnEdit = vi.fn();
+const mockOnCancelEdit = vi.fn();
+
+function renderItem(props = {}, task = BASE_TASK) {
+  localStorage.setItem(TASKS_LS_KEY, JSON.stringify([task]));
+  return render(
+    <TaskItem
+      task={task}
+      isEditing={false}
+      onEdit={mockOnEdit}
+      onCancelEdit={mockOnCancelEdit}
+      {...props}
+    />
+  );
+}
+
+function getStored() {
+  return JSON.parse(localStorage.getItem(TASKS_LS_KEY) ?? '[]');
+}
+
+describe('TaskItem', () => {
+  // let user;
+
+  // beforeEach(() => {
+  //   vi.useFakeTimers();
+  //   user = userEvent.setup({ advanceTimers: (ms) => vi.advanceTimersByTime(ms) });
+  // });
+
+  // afterEach(() => {
+  //   vi.runOnlyPendingTimers();
+  //   vi.useRealTimers();
+  // });
+
+  it('should render the task text', () => {
+    renderItem();
+    expect(screen.getByText(/Test task item/)).toBeInTheDocument();
+  });
+
+  it('should render TaskEditForm when isEditing is true', () => {
+    renderItem({ isEditing: true });
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toHaveValue(BASE_TASK.text);
+  });
+
+  it('should call onEdit when task text is clicked', async () => {
+    const user = userEvent.setup();
+    renderItem()
+    await user.click(screen.getByText(/Test task item/));
+    expect(mockOnEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call onEdit when task text is clicked while busy', async () => {
+    const user = userEvent.setup();
+    renderItem();
+
+    await user.click(screen.getByRole('button', { name: /mark task as complete/i }));
+    await user.click(screen.getByText(/Test task item/i));
+    expect(mockOnEdit).not.toHaveBeenCalled();
+  });
+
+  it('should show undo button and hide action buttons after clicking complete', async () => {
+    const user = userEvent.setup();
+    renderItem()
+
+    await user.click(screen.getByRole('button', { name: /mark task as complete/i }));
+    expect(screen.getByRole('button', { name: /undo/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /mark task as complete/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /delete task/i })).not.toBeInTheDocument();
+  });
+
+  it('should show undo button and hide action buttons after clicking delete', async () => {
+    const user = userEvent.setup();
+    renderItem()
+
+    await user.click(screen.getByRole('button', { name: /delete task/i }));
+    expect(screen.getByRole('button', { name: /undo/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /mark task as complete/i })).not.toBeInTheDocument();
+  });
+
+  it('should restore action buttons and hide undo after clicking undo', async () => {
+    const user = userEvent.setup();
+    renderItem()
+
+    await user.click(screen.getByRole('button', { name: /mark task as complete/i }));
+    await user.click(screen.getByRole('button', { name: /undo/i }));
+    expect(screen.queryByRole('button', { name: /undo/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /mark task as complete/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /delete task/i })).toBeInTheDocument();
+  });
+
+  it('should set status to completed in localStorage after UNDO_DELAY', () => {
+    vi.useFakeTimers();
+    renderItem();
+    fireEvent.click(screen.getByRole('button', { name: /mark task as complete/i }));
+    act(() => vi.advanceTimersByTime(4000));
+    const task = getStored().find(t => t.id === BASE_TASK.id);
+    expect(task.status).toBe('completed');
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('should set status to deleted in localStorage after UNDO_DELAY', () => {
+    vi.useFakeTimers();
+    renderItem()
+
+    fireEvent.click(screen.getByRole('button', { name: /delete task/i }));
+    act(() => vi.advanceTimersByTime(4000));
+    const task = getStored().find(t => t.id === BASE_TASK.id);
+    expect(task.status).toBe('deleted');
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('should not change status in localStorage if undo is clicked before UNDO_DELAY', () => {
+    vi.useFakeTimers();
+    renderItem()
+
+    fireEvent.click(screen.getByRole('button', { name: /mark task as complete/i }));
+    fireEvent.click(screen.getByRole('button', { name: /undo/i }));
+
+    act(() => vi.advanceTimersByTime(4000));
+    const task = getStored().find(t => t.id === BASE_TASK.id);
+    expect(task.status).toBe('pending');
+    expect(screen.queryByRole('button', { name: /undo/i })).not.toBeInTheDocument();
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('should call onCancelEdit and update text in localStorage when edit is saved', async () => {
+    const user = userEvent.setup();
+    renderItem({ isEditing: true });
+
+    const input = screen.getByRole('textbox');
+
+    await user.clear(input)
+    await user.type(input, 'New text{Enter}')
+
+    expect(mockOnCancelEdit).toHaveBeenCalledTimes(1);
+    const task = getStored().find(t => t.id === BASE_TASK.id);
+    expect(task.text).toBe('New text');
+  });
+
+  it('should call onCancelEdit without updating localStorage when Escape is pressed', async () => {
+    const user = userEvent.setup();
+    renderItem({ isEditing: true });
+
+    await user.keyboard('{Escape}')
+    expect(mockOnCancelEdit).toHaveBeenCalledTimes(1);
+    const task = getStored().find(t => t.id === BASE_TASK.id);
+    expect(task.text).toBe(BASE_TASK.text);
+  });
+});

--- a/frontend/src/components/Quadrant/index.jsx
+++ b/frontend/src/components/Quadrant/index.jsx
@@ -1,12 +1,10 @@
-import {useState} from 'react'
-
 import "./Quadrant.css";
 import TaskItem from "./TaskItem";
 
-const Quadrant = ({ config, tasks }) => {
+const Quadrant = ({ config, tasks, editingTaskId, onEdit, onCancelEdit }) => {
   const { label, action, cssVarBg, cssVarBorder, cssVarText } = config;
   // To track which tesk is being edited, one task at a time
-  const [editingId, setEditingId] = useState(null);
+  // const [editingId, setEditingId] = useState(null);
 
   return (
     <div
@@ -37,9 +35,9 @@ const Quadrant = ({ config, tasks }) => {
             <TaskItem
               key={task.id}
               task={task}
-              isEditing={editingId === task.id}
-              onEdit={() => setEditingId(task.id)}
-              onCancelEdit={() => setEditingId(null)}
+              isEditing={editingTaskId === task.id}
+              onEdit={onEdit}
+              onCancelEdit={onCancelEdit}
             />
           ))}
         </ul>

--- a/frontend/src/components/TaskForm/TaskForm.test.jsx
+++ b/frontend/src/components/TaskForm/TaskForm.test.jsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { render } from '../../../testSetup';
+
+import { screen, waitFor, render } from '../../../testSetup';
 import TaskForm from './index.jsx';
 import { TASKS_LS_KEY } from '../../hooks/useTasks';
 

--- a/frontend/src/components/TaskForm/TaskForm.test.jsx
+++ b/frontend/src/components/TaskForm/TaskForm.test.jsx
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../testSetup';
+import TaskForm from './index.jsx';
+import { TASKS_LS_KEY } from '../../hooks/useTasks';
+
+const mockSetNotification = vi.fn();
+vi.mock('../../stores/useNotification', () => ({
+  useNotificationActions: () => ({ setNotification: mockSetNotification }),
+}));
+
+function getStored() {
+  return JSON.parse(localStorage.getItem(TASKS_LS_KEY) ?? '[]');
+}
+
+function renderForm() {
+  localStorage.setItem(TASKS_LS_KEY, JSON.stringify([]));
+  return render(<TaskForm />);
+}
+
+describe('TaskForm initial render', () => {
+  it('should render the text input field', () => {
+    renderForm();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('should render the Add button', () => {
+    renderForm();
+    expect(screen.getByRole('button', { name: /add/i })).toBeInTheDocument();
+  });
+
+  it('should render the Important checkbox', () => {
+    renderForm();
+    expect(screen.getByRole('checkbox', { name: /important/i })).toBeInTheDocument();
+  });
+
+  it('should render the Urgent checkbox', () => {
+    renderForm();
+    expect(screen.getByRole('checkbox', { name: /urgent/i })).toBeInTheDocument();
+  });
+
+  it('should start with an empty text input', () => {
+    renderForm();
+    expect(screen.getByRole('textbox')).toHaveValue('');
+  });
+
+  it('should start with both checkboxes unchecked', () => {
+    renderForm();
+    expect(screen.getByRole('checkbox', { name: /important/i })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /urgent/i })).not.toBeChecked();
+  });
+});
+
+describe('TaskForm quadrant preview', () => {
+  it('should not show the preview when no checkbox is checked', () => {
+    renderForm();
+    expect(screen.queryByText(/Q1|Q2|Q3|Q4/)).not.toBeInTheDocument();
+  });
+
+  it('should show Q1 · Do First when both urgent and important are checked', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.click(screen.getByRole('checkbox', { name: /urgent/i }));
+    await user.click(screen.getByRole('checkbox', { name: /important/i }));
+
+    expect(screen.getByText(/Q1 · Do First/)).toBeInTheDocument();
+  });
+
+  it('should show Q2 · Schedule when only important is checked', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.click(screen.getByRole('checkbox', { name: /important/i }));
+
+    expect(screen.getByText(/Q2 · Schedule/)).toBeInTheDocument();
+  });
+
+  it('should show Q3 · Delegate when only urgent is checked', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.click(screen.getByRole('checkbox', { name: /urgent/i }));
+
+    expect(screen.getByText(/Q3 · Delegate/)).toBeInTheDocument();
+  });
+});
+
+describe('TaskForm validation', () => {
+  it('should show an error when submitted with an empty input', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.click(screen.getByRole('button', { name: /add/i }));
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/required/i)).toBeInTheDocument();
+  });
+
+  it('should show an error when submitted with a whitespace-only input', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.type(screen.getByRole('textbox'), '   ');
+    await user.click(screen.getByRole('button', { name: /add/i }));
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('should set aria-invalid on the input when there is an error', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.click(screen.getByRole('button', { name: /add/i }));
+
+    expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('should clear the error when the user starts typing after a failed submit', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.click(screen.getByRole('button', { name: /add/i }));
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    await user.type(screen.getByRole('textbox'), 'A');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('should not add a task to localStorage when validation fails', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.click(screen.getByRole('button', { name: /add/i }));
+
+    expect(getStored()).toHaveLength(0);
+  });
+});
+
+describe('TaskForm successful submission', () => {
+  it('should add the task to localStorage on valid submit', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.type(screen.getByRole('textbox'), 'Buy milk');
+    await user.click(screen.getByRole('button', { name: /add/i }));
+
+    await waitFor(() => {
+      const stored = getStored();
+      expect(stored).toHaveLength(1);
+      expect(stored[0].text).toBe('Buy milk');
+    });
+  });
+
+  it('should trim whitespace from the task text before saving', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.type(screen.getByRole('textbox'), '  Buy milk  ');
+    await user.click(screen.getByRole('button', { name: /add/i }));
+
+    await waitFor(() => {
+      expect(getStored()[0].text).toBe('Buy milk');
+    });
+  });
+
+  it('should save the correct urgent and important flags', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.type(screen.getByRole('textbox'), 'Urgent task');
+    await user.click(screen.getByLabelText(/urgent/i));
+    await user.click(screen.getByRole('button', { name: /add/i }));
+
+    await waitFor(() => {
+      const stored = getStored();
+      expect(stored[0].urgent).toBe(true);
+      expect(stored[0].important).toBe(false);
+    });
+  });
+
+  it('should reset the text input after a successful submit', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.type(screen.getByRole('textbox'), 'Buy milk');
+    await user.click(screen.getByRole('button', { name: /add/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toHaveValue('');
+    });
+  });
+
+  it('should uncheck both checkboxes after a successful submit', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.type(screen.getByRole('textbox'), 'Buy milk');
+    await user.click(screen.getByLabelText(/urgent/i));
+    await user.click(screen.getByLabelText(/important/i));
+    await user.click(screen.getByRole('button', { name: /add/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('checkbox', { name: /urgent/i })).not.toBeChecked();
+      expect(screen.getByRole('checkbox', { name: /important/i })).not.toBeChecked();
+    });
+  });
+
+  it('should fire a success notification after a valid submit', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.type(screen.getByRole('textbox'), 'Buy milk');
+    await user.click(screen.getByRole('button', { name: /add/i }));
+
+    await waitFor(() => {
+      expect(mockSetNotification).toHaveBeenCalledWith({
+        message: "New Task 'Buy milk' added",
+        type: 'success',
+      });
+    });
+  });
+
+  it('should not fire a notification when validation fails', async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    await user.click(screen.getByRole('button', { name: /add/i }));
+
+    expect(mockSetNotification).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/TaskForm/index.jsx
+++ b/frontend/src/components/TaskForm/index.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { useTaskContext } from "../../context/UseTaskContext";
+import { useTaskContext } from "../../context/useTaskContext";
 import { useNotificationActions } from "../../stores/useNotification";
 import { validateTaskText } from "../../utils/helpers";
 import "./TaskForm.css";

--- a/frontend/src/components/TaskForm/index.jsx
+++ b/frontend/src/components/TaskForm/index.jsx
@@ -5,7 +5,7 @@ import { useNotificationActions } from "../../stores/useNotification";
 import { validateTaskText } from "../../utils/helpers";
 import "./TaskForm.css";
 
-const TaskForm = () => {
+const TaskForm = ({ onFocus }) => {
   const { addTask } = useTaskContext();
   const [text, setText] = useState("");
   const [important, setImportant] = useState(false);
@@ -15,9 +15,12 @@ const TaskForm = () => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    
+
     const error = validateTaskText(text);
-    if (error) { setError(error); return; }
+    if (error) {
+      setError(error);
+      return;
+    }
 
     const trimmed = text.trim();
 
@@ -45,7 +48,12 @@ const TaskForm = () => {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="task-form" noValidate>
+    <form
+      onSubmit={handleSubmit}
+      onFocus={onFocus}
+      className="task-form"
+      noValidate
+    >
       <div className="input-row">
         <input
           type="text"
@@ -62,10 +70,10 @@ const TaskForm = () => {
         </button>
       </div>
       {error && (
-        <p 
+        <p
           className="task-form-error"
           id="input-error"
-          role='alert' // announce error on screen reader
+          role="alert" // announce error on screen reader
           aria-live="polite"
         >
           {error}

--- a/frontend/src/context/TaskContext.jsx
+++ b/frontend/src/context/TaskContext.jsx
@@ -1,3 +1,10 @@
+/**
+ * Manages "where" notes live.
+ * - Creates the Context and the Provider wrapper.
+ * - Uses the logic hook to "broadcast" state to the entire app tree.
+ * - Prevents "prop drilling" by making the engine's output global.
+ */
+
 import { TaskContext } from "./useTaskContext";
 import { useTasks } from "../hooks/useTasks";
 import { initialTasks } from "../data/mockTasks_v1";

--- a/frontend/src/context/TaskContext.jsx
+++ b/frontend/src/context/TaskContext.jsx
@@ -1,4 +1,4 @@
-import { TaskContext } from "./UseTaskContext";
+import { TaskContext } from "./useTaskContext";
 import { useTasks } from "../hooks/useTasks";
 import { initialTasks } from "../data/mockTasks_v1";
 

--- a/frontend/src/context/useTaskContext.js
+++ b/frontend/src/context/useTaskContext.js
@@ -1,6 +1,6 @@
 import { createContext, useContext } from "react";
 
-export const TaskContext = createContext(null)
+export const TaskContext = createContext()
 
 export const useTaskContext = () => {
   const context = useContext(TaskContext);

--- a/frontend/src/context/useTaskContext.js
+++ b/frontend/src/context/useTaskContext.js
@@ -1,3 +1,10 @@
+/**
+ * The interface that manages "how" components access the data.
+ * - A hook that abstracts the useContext call.
+ * - Provides a clean API for components: const { tasks } = useTaskContext().
+ * - Includes a safety check to ensure it's used within a Provider.
+ */
+
 import { createContext, useContext } from "react";
 
 export const TaskContext = createContext()

--- a/frontend/src/hooks/useTasks.js
+++ b/frontend/src/hooks/useTasks.js
@@ -31,15 +31,17 @@ import { useState, useEffect } from 'react';
  * const { tasks, pendingTasks, addTask } = useTasks(initialTasks);
  * addTask({ text: 'Fix bug', important: true, urgent: true });
  */
+
+const TASKS_STORAGE_KEY = 'matrix_tasks';
 export const useTasks = (initialData=[]) => {
 
     const [tasks, setTasks] = useState(() => {
-        const saved = localStorage.getItem('matrix_tasks');
+        const saved = localStorage.getItem(TASKS_STORAGE_KEY);
         return saved ? JSON.parse(saved) : initialData;
     });
 
     useEffect(() => {
-        localStorage.setItem('matrix_tasks', JSON.stringify(tasks));
+        localStorage.setItem(TASKS_STORAGE_KEY, JSON.stringify(tasks));
     }, [tasks]);
 
     //--CRUD Operations

--- a/frontend/src/hooks/useTasks.js
+++ b/frontend/src/hooks/useTasks.js
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react';
 
 /**
- * useTasks Hook
+ * useTasks Hook (Pure Logic)
  * 
  * Manages task state with localStorage persistence.
  * Handles CRUD operations and provides filtered task groupings for the Eisenhower Matrix.
+ * Decoupled from the UI and Context so it can be used independently 
  * 
  * @param {Array} initialData - Initial tasks to load on first run (default: empty array)
  * 
@@ -32,7 +33,7 @@ import { useState, useEffect } from 'react';
  * addTask({ text: 'Fix bug', important: true, urgent: true });
  */
 
-const TASKS_LS_KEY = 'matrix_tasks';
+export const TASKS_LS_KEY = 'matrix_tasks';
 
 export const useTasks = (initialData=[]) => {
 

--- a/frontend/src/hooks/useTasks.js
+++ b/frontend/src/hooks/useTasks.js
@@ -10,7 +10,6 @@ import { useState, useEffect } from 'react';
  * 
  * @returns {Object} Task state management object
  * @returns {Array} tasks - All tasks (flattened)
- * @returns {Object} groupedTasks - Tasks grouped by quadrant (q1, q2, q3, q4)
  * @returns {Array} pendingTasks - Only tasks with status='pending'
  * @returns {Function} addTask - Add a new task
  * @returns {Function} updateTask - Update an existing task
@@ -24,6 +23,7 @@ import { useState, useEffect } from 'react';
  *   urgent: boolean,
  *   status: 'pending' | 'completed' | 'deleted',
  *   createdAt: ISO string,
+ *   updatedAt: ISO string,
  *   completedAt: ISO string | null
  * }
  * 
@@ -32,16 +32,17 @@ import { useState, useEffect } from 'react';
  * addTask({ text: 'Fix bug', important: true, urgent: true });
  */
 
-const TASKS_STORAGE_KEY = 'matrix_tasks';
+const TASKS_LS_KEY = 'matrix_tasks';
+
 export const useTasks = (initialData=[]) => {
 
     const [tasks, setTasks] = useState(() => {
-        const saved = localStorage.getItem(TASKS_STORAGE_KEY);
+        const saved = localStorage.getItem(TASKS_LS_KEY);
         return saved ? JSON.parse(saved) : initialData;
     });
 
     useEffect(() => {
-        localStorage.setItem(TASKS_STORAGE_KEY, JSON.stringify(tasks));
+        localStorage.setItem(TASKS_LS_KEY, JSON.stringify(tasks));
     }, [tasks]);
 
     //--CRUD Operations
@@ -55,13 +56,16 @@ export const useTasks = (initialData=[]) => {
      */
     const addTask = (taskObj) => {
         const {text, important, urgent} = taskObj;
+        if (!text.trim()) return;
+        const timestamp = new Date().toISOString();
         const newTask = {
             id: crypto.randomUUID(),
             text, 
             urgent,
             important,
             status: 'pending', // 'pending' | 'completed' | 'deleted'
-            createdAt: new Date().toISOString(),
+            createdAt: timestamp,
+            updatedAt: timestamp,
             completedAt: null
         }
         setTasks((prev) => [...prev, newTask]);
@@ -77,15 +81,16 @@ export const useTasks = (initialData=[]) => {
             prev.map((t) => {
                 if (t.id === id) {
                     let completedAt = t.completedAt;
+                    const timestamp = new Date().toISOString();
 
                     // Handle the timestamp based on the new status
                     if (updates.status === 'completed') {
-                        completedAt = new Date().toISOString();
+                        completedAt = timestamp;
                     } else if (updates.status === 'pending') {
                         completedAt = null; // Clear it if moving back to pending
                     }
 
-                    return { ...t, ...updates, completedAt };
+                    return { ...t, ...updates, updatedAt: timestamp, completedAt };
                 }
                 return t;
             })

--- a/frontend/src/hooks/useTasks.test.js
+++ b/frontend/src/hooks/useTasks.test.js
@@ -1,3 +1,4 @@
+// Unit test
 import { renderHook, act } from '@testing-library/react';
 import { useTasks } from './useTasks';
 import { vi, expect, it, describe } from 'vitest';

--- a/frontend/src/hooks/useTasks.test.js
+++ b/frontend/src/hooks/useTasks.test.js
@@ -1,0 +1,199 @@
+import { renderHook, act } from '@testing-library/react';
+import { useTasks } from './useTasks';
+import { vi, expect, it, describe } from 'vitest';
+
+const LS_KEY = 'matrix_tasks';
+ 
+function getStored() {
+  return JSON.parse(localStorage.getItem(LS_KEY) ?? '[]');
+}
+
+const createMockTask = () => {
+  const timestamp = new Date().toISOString();
+  
+  return {
+    id: '1',
+    text: 'Initial',
+    urgent: true,
+    important: true,
+    status: 'pending',
+    updatedAt: timestamp,
+    createdAt: timestamp,
+    completedAt: null,
+  };
+};
+
+function seedHook() {
+    const seed = [createMockTask()];
+    return renderHook(() => useTasks(seed));
+  }
+
+describe('useTasks Hook', () => {
+  // initial data
+  it('should initialize with initialData if localStorage is empty', () => {
+    const initial = [createMockTask()];
+    const { result } = renderHook(() => useTasks(initial));
+    expect(result.current.tasks).toHaveLength(1);
+    expect(result.current.tasks).toEqual(initial);
+  });
+
+  // Add task
+
+  it('should add a new task with correct default values', () => {
+    const { result } = renderHook(() => useTasks());
+    
+    act(() => {
+      result.current.addTask({ 
+        text: 'New Task', 
+        important: true, 
+        urgent: true 
+      });
+    });
+
+    const addedTask = result.current.tasks[0];
+    expect(result.current.tasks).toHaveLength(1);
+    expect(addedTask.text).toBe('New Task');
+    expect(addedTask.urgent).toBe(true);
+    expect(addedTask.important).toBe(true);
+    expect(addedTask.status).toBe('pending');
+    expect(addedTask.createdAt).toBeDefined();
+    expect(addedTask.updatedAt).toBeDefined();
+    expect(addedTask.completedAt).toBeNull();
+    expect(addedTask.id).toBeDefined();
+  });
+
+  it('should persist the new task to localStorage', () => {
+    const { result } = renderHook(() => useTasks());
+ 
+    act(() => {
+      result.current.addTask({ 
+        text: 'Persist me', 
+        urgent: false, 
+        important: true 
+      });
+    });
+ 
+    const stored = getStored();
+    expect(stored).toHaveLength(1);
+    expect(stored[0].text).toBe('Persist me');
+  });
+ 
+  it('should accumulate multiple tasks', () => {
+    const { result } = renderHook(() => useTasks());
+ 
+    act(() => {
+      result.current.addTask({ text: 'Task A', urgent: true, important: true });
+      result.current.addTask({ text: 'Task B', urgent: false, important: false });
+    });
+ 
+    expect(result.current.tasks).toHaveLength(2);
+  });
+
+  it('should not add a task if the text is empty or whitespace', () => {
+    const {result} = seedHook();
+    
+    act(() => {
+      result.current.addTask({ text: '   ', important: false, urgent: false });
+    });
+
+    expect(result.current.tasks).toHaveLength(1);
+  });
+
+  // Update task
+
+  it('should update task text and properties', () => {
+    const {result} = seedHook();
+
+    act(() => {
+      result.current.updateTask('1', { text: 'Updated Text' });
+    });
+
+    expect(result.current.tasks[0].text).toBe('Updated Text');
+  });
+
+  it('should set completedAt timestamp when status changes to completed', () => {
+    const {result} = seedHook();
+
+    // Toggle to completed
+    act(() => {
+      result.current.updateTask('1', { status: 'completed' });
+    });
+    expect(result.current.tasks[0].completedAt).not.toBeNull();
+  });
+
+  it('should clear completedAt when reverting from completed back to pending', () => {
+    const {result} = seedHook();
+
+    act(() => {
+      result.current.updateTask('1', { status: 'completed' });
+    });
+    expect(result.current.tasks[0].completedAt).not.toBeNull();
+ 
+    act(() => {
+      result.current.updateTask('1', { status: 'pending' });
+    });
+ 
+    const task = result.current.tasks.find((t) => t.id === '1');
+    expect(task.status).toBe('pending');
+    expect(task.completedAt).toBeNull();
+  });
+
+  it('should only update text and updatedAt when update text', () => {
+    const initial = [createMockTask()];
+    const { result } = renderHook(() => useTasks(initial));
+ 
+    act(() => {
+      result.current.updateTask('1', { text: 'Updated text' });
+    });
+ 
+    const task = result.current.tasks.find((t) => t.id === '1');
+    expect(task.text).toBe('Updated text');
+    expect(task.important).toBe(true);
+    expect(task.urgent).toBe(true);
+    expect(task.status).toBe('pending');
+    expect(task.completedAt).toBeNull();
+    expect(task.createdAt).toEqual(initial[0].createdAt);
+    expect(task.updatedAt).not.toBe(initial[0].updatedAt);
+  });
+
+  it('should persist the update to localStorage', () => {
+    const { result } = seedHook();
+ 
+    act(() => {
+      result.current.updateTask('1', {
+        important: false,
+        urgent: false,
+      });
+    });
+ 
+    const stored = getStored();
+    const task = stored.find((t) => t.id === '1');
+    expect(task.urgent).toBe(false);
+    expect(task.important).toBe(false);
+  });
+
+  it('should delete a task by id', () => {
+    const initial = [createMockTask()];
+    const { result } = renderHook(() => useTasks(initial));
+
+    act(() => {
+      result.current.deleteTask('1');
+    });
+
+    expect(result.current.tasks).toHaveLength(0);
+  });
+
+  it('should persist changes to localStorage', () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
+    const { result } = renderHook(() => useTasks());
+
+    act(() => {
+      result.current.addTask({ text: 'Persist Task' });
+    });
+
+    expect(setItemSpy).toHaveBeenCalled();
+    const lastCallIndex = setItemSpy.mock.calls.length - 1;
+    const savedData = JSON.parse(setItemSpy.mock.calls[lastCallIndex][1]);
+    expect(savedData[0].text).toBe('Persist Task');
+  });
+});

--- a/frontend/src/pages/MatrixPage.jsx
+++ b/frontend/src/pages/MatrixPage.jsx
@@ -1,3 +1,5 @@
+import {useState} from 'react'
+
 import TaskForm from "../components/TaskForm";
 import Quadrant from "../components/Quadrant";
 import { QUADRANTS } from "../constants/matrixConfig";
@@ -6,6 +8,7 @@ import "./MatrixPage.css";
 
 export default function MatrixPage() {
   const { pendingTasks } = useTaskContext();
+  const [editingTaskId, setEditingTaskId] = useState(null);
 
   return (
     <div className="matrix-page">
@@ -16,7 +19,7 @@ export default function MatrixPage() {
         </p>
       </div>
 
-      <TaskForm />
+      <TaskForm onFocus={() => setEditingTaskId(null)} />
 
       <div className="matrix-grid">
         {QUADRANTS.map((config) => {
@@ -29,6 +32,9 @@ export default function MatrixPage() {
               key={config.id}
               config={config}
               tasks={filtered}
+              editingTaskId={editingTaskId}
+              onEdit={(id) => setEditingTaskId(id)}
+              onCancelEdit={() => setEditingTaskId(null)}
             />
           );
         })}

--- a/frontend/src/pages/MatrixPage.jsx
+++ b/frontend/src/pages/MatrixPage.jsx
@@ -1,7 +1,7 @@
 import TaskForm from "../components/TaskForm";
 import Quadrant from "../components/Quadrant";
 import { QUADRANTS } from "../constants/matrixConfig";
-import { useTaskContext } from "../context/UseTaskContext";
+import { useTaskContext } from "../context/useTaskContext";
 import "./MatrixPage.css";
 
 export default function MatrixPage() {

--- a/frontend/src/utils/helpers.test.js
+++ b/frontend/src/utils/helpers.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { validateTaskText, formatDate } from './helpers';
+
+describe('validateTaskText', () => {
+  it('should return an error for an empty string', () => {
+    expect(validateTaskText('')).toBe('Task text is required.');
+  });
+
+  it('should return an error for a whitespace-only string', () => {
+    expect(validateTaskText('   ')).toBe('Task text is required.');
+  });
+
+  it('should return an error for a tab-only string', () => {
+    expect(validateTaskText('\t\n')).toBe('Task text is required.');
+  });
+
+  it('should return no error for a normal string', () => {
+    expect(validateTaskText('Buy milk')).toBe('');
+  });
+
+  it('should return no error for exactly 200 characters', () => {
+    const text = 'a'.repeat(200);
+    expect(validateTaskText(text)).toBe('');
+  });
+
+  it('should return an error for 201 characters', () => {
+    const text = 'a'.repeat(201);
+    expect(validateTaskText(text)).toBe('Task cannot be longer than 200 characters.');
+  });
+
+  it('should trim before checking length — 200 chars with surrounding spaces should be valid', () => {
+    const text = ' ' + 'a'.repeat(200) + ' ';
+    expect(validateTaskText(text)).toBe('');
+  });
+});
+
+describe('formatDate', () => {
+  it('should format an ISO string in en-NZ locale with day first', () => {
+    const iso = '2024-03-15T09:00:00.000Z';
+    const result = formatDate(iso);
+    expect(result).toMatch(/15/);
+    expect(result).toMatch(/2024/);
+  });
+
+  it('should return a string', () => {
+    expect(typeof formatDate(new Date().toISOString())).toBe('string');
+  });
+
+  it('should not throw for a valid ISO string', () => {
+    expect(() => formatDate('2023-01-01T00:00:00.000Z')).not.toThrow();
+  });
+});

--- a/frontend/testSetup.js
+++ b/frontend/testSetup.js
@@ -1,0 +1,7 @@
+import { afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+afterEach(() => {
+  cleanup()
+})

--- a/frontend/testSetup.js
+++ b/frontend/testSetup.js
@@ -2,7 +2,7 @@ import { beforeEach, vi, afterEach } from 'vitest'
 import { cleanup, render } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 
-import { TasksProvider } from './src/context/TaskContext'
+import { TaskProvider } from './src/context/TaskContext'
 
 beforeEach(() => {
   localStorage.clear();
@@ -13,9 +13,9 @@ afterEach(() => {
   cleanup()
 })
 
+// For integration test
 const customRender = (ui, options) =>
-  render(ui, { wrapper: TasksProvider, ...options });
+  render(ui, { wrapper: TaskProvider, ...options });
 
-// 3. Export everything from RTL + our custom render
 export * from '@testing-library/react';
 export { customRender as render };

--- a/frontend/testSetup.js
+++ b/frontend/testSetup.js
@@ -1,7 +1,21 @@
-import { afterEach } from 'vitest'
-import { cleanup } from '@testing-library/react'
+import { beforeEach, vi, afterEach } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
+
+import { TasksProvider } from './src/context/TaskContext'
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+});
 
 afterEach(() => {
   cleanup()
 })
+
+const customRender = (ui, options) =>
+  render(ui, { wrapper: TasksProvider, ...options });
+
+// 3. Export everything from RTL + our custom render
+export * from '@testing-library/react';
+export { customRender as render };

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './testSetup.js', 
+  }
 })

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   test: {


### PR DESCRIPTION
## Summary
Adds test coverage for `TaskForm`, `useTasks`, `TaskEditForm`, `TaskItem`, and `Quadrant` following the established architecture — unit tests for context-free components, integration tests for components that depend on `TaskProvider`.

## Changes
- Added `TaskEditForm.test.jsx` as unit tests covering validation, key handling, save and cancel behaviour
- Added `TaskItem.test.jsx` as integration tests covering undo timer flow, edit mode, and localStorage assertions
- Added `Quadrant.test.jsx` as integration tests covering empty state, task count, and single-edit isolation
- Added `TaskForm.test.jsx` as integration tests covering initial render, quadrant preview, validation, and successful submission
- Added `useTasks.test.jsx` as unit test covering custom hook logic

## Notes
- Used `fireEvent` over `userEvent` in timer-dependent tests in `TaskItem.test.jsx` because `userEvent` has timer configured; `fireEvent` is appropriate where the assertion is about timer behaviour
- Scoped `vi.useFakeTimers()` per test rather than in `beforeEach` — fake timers leak into `userEvent`'s internal `setTimeout` in non-timer tests and cause hangs
- `TaskEditForm` imported `render` from `@testing-library/react` directly, not from `testSetup` — it has no context dependency so wrapping in `TaskProvider` adds no value
- Followed existing pattern of pre-seeding `localStorage` with `TASKS_LS_KEY` before each render to prevent default task seeding from bleeding into assertions

---
Closes #55